### PR TITLE
Sanitize the Dashboard widget input fields

### DIFF
--- a/includes/dashboard-widgets.php
+++ b/includes/dashboard-widgets.php
@@ -3,29 +3,35 @@
 /*
  * Add a dashboard widget giving contact details for support.
  */
+add_action('wp_dashboard_setup', 'sc_custom_dashboard_widget');
 
-    add_action('wp_dashboard_setup', 'sc_custom_dashboard_widget');
-
-    function sc_custom_dashboard_widget() {
-
+function sc_custom_dashboard_widget() {
     global $wp_meta_boxes;
-
     $options = get_option('sc_utility_settings');
-
-    if (isset($options['enable_widget']) == 1)
+    if (isset($options['enable_widget']) == 1) {
         wp_add_dashboard_widget('custom_help_widget', $options['title'] . ' Support', 'sc_custom_dashboard_support');
+	}
+}
 
-  }
+function sc_custom_dashboard_support() {
+	$options = get_option('sc_utility_settings');
 
-  function sc_custom_dashboard_support() {
+	// Check if the image is set and not empty, then add the image code.
+	$dash_image = $options['image'];
+	if ( isset($dash_image) && $dash_image != '' ) {
+		echo '<p><img src="' . esc_url($dash_image) . '" style="width:80px;" /></p>';
+	}
 
-    $options = get_option('sc_utility_settings');
-
-    echo '<p><img src="' . $options['image'] . '" style="width:80px;" /></p><p><b>Need help?</b>
-   Contact the developers at ' . $options['title'] . ' by <a href="mailto:' . $options['email'] . '" target=_blank"><u>email</u></a>
-   or phone ' . $options['phone'] . '.<p>';
-
-  }
+	// Check if title settings are set and not empty
+	$title = (isset($options['title']) && $options['title'] != '') ? ' at ' . $options['title'] : '';
+	echo '<p><b>Need help?</b> Contact the developers'  . $title . '<p>';
+	
+	// Check if email settings are set and not empty
+	echo (isset($options['email']) && $options['email'] != '') ? '<p>Email: <a href="mailto:' . $options['email'] . ' target=_blank"><u>' . $options['email'] . '</u></a></p>' : '';
+	
+	// Check if phone settings are set and not empty
+	echo (isset($options['phone']) && $options['phone'] != '') ? '<p>Phone: ' . $options['phone'] . '</p>' : '';
+}
 
 
  /**

--- a/includes/register-settings.php
+++ b/includes/register-settings.php
@@ -176,16 +176,16 @@
 
         $new_input = array();
 
-        if(isset($input['email']))
+        if(isset($input['email']) && $input['title'] != '')
             $new_input['email'] = sanitize_text_field($input['email']);
 
-        if(isset($input['title']))
+        if(isset($input['title']) && $input['title'] != '')
             $new_input['title'] = sanitize_text_field($input['title']);
 
-        if(isset($input['phone']))
+        if(isset($input['phone']) && $input['phone'] != '')
             $new_input['phone'] = sanitize_text_field($input['phone']);
 
-        if(isset($input['image']))
+        if(isset($input['image']) && $input['image'] != '')
             $new_input['image'] = sanitize_text_field($input['image']);
 
         if(isset($input['enable_widget']))
@@ -251,7 +251,7 @@
         if(isset($input['trackbacks']))
             $new_input['trackbacks'] = sanitize_text_field($input['trackbacks']);
 
-        if(isset($input['revisions']))
+        if(isset($input['revisions']) && $input['revisions'] != '')
             $new_input['revisions'] = sanitize_text_field($input['revisions']);
 
         if(isset($input['authors']))


### PR DESCRIPTION
Before the code has been storing an empty setting. This PR seeks:

- To stop saving an empty string for support logo, phone number, email and revisions.
- Verify if the returned data is not empty then return HTML. The HTML structure change is suggested to change so that HTML is returned if the data is not empty.

### Screenshots
![Screenshot 2020-01-26 at 13 51 35](https://user-images.githubusercontent.com/7713923/73134140-2622f380-4044-11ea-997c-7a5af3be6aa8.png)

![Screenshot 2020-01-26 at 13 51 23](https://user-images.githubusercontent.com/7713923/73134141-2622f380-4044-11ea-8ddf-537089028b1c.png)
